### PR TITLE
Added method to show the bundle for a class

### DIFF
--- a/Tweak.xm
+++ b/Tweak.xm
@@ -187,6 +187,13 @@ static UILongPressGestureRecognizer *RegisterLongPressGesture(UIWindow *window, 
 %end
 
 %group commonFLEXHooks
+%hook NSObject
+%new
++ (NSBundle *)__bundle__ {
+	return [NSBundle bundleForClass:self];
+}
+%end
+
 %hook UIViewController
 -(BOOL)_canShowWhileLocked {
 	UIViewController *currentViewController = self;


### PR DESCRIPTION
FLEXing has a handy method which allows to quickly find the framework to which a class belongs. As someone who used that a lot in the past, i am proposing putting it here too. I think this is very useful for us, as tweak developers so that we can load the framework before calling %init in our tweaks.